### PR TITLE
Sync `development` with `master`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/pom.xml
+++ b/pom.xml
@@ -13,20 +13,6 @@
   ~ limitations under the License.
   -->
 
-<!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -41,7 +27,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>8</java.version>
+        <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <!-- GitHub -->
@@ -117,55 +103,73 @@
             <id>sonatype-ossrh</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <!-- ProtocolLib -->
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+        </repository>
+        <repository>
+            <id>aikar</id>
+            <url>http://repo.aikar.co/nexus/content/groups/aikar/</url>
+        </repository>
     </repositories>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <tags>
-                        <tag>
-                            <name>apiNote</name>
-                            <placement>a</placement>
-                            <head>API note</head>
-                        </tag>
-                        <tag>
-                            <name>implNote</name>
-                            <placement>a</placement>
-                            <head>Implementation note</head>
-                        </tag>
-                        <tag>
-                            <name>implSpec</name>
-                            <placement>a</placement>
-                            <head>Implementation specification</head>
-                        </tag>
-                    </tags>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <tags>
+                            <tag>
+                                <name>apiNote</name>
+                                <placement>a</placement>
+                                <head>API note</head>
+                            </tag>
+                            <tag>
+                                <name>implNote</name>
+                                <placement>a</placement>
+                                <head>Implementation note</head>
+                            </tag>
+                            <tag>
+                                <name>implSpec</name>
+                                <placement>a</placement>
+                                <head>Implementation specification</head>
+                            </tag>
+                        </tags>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Own modules -->
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>zaraza-common-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Runtime -->
             <dependency>
                 <groupId>org.spigotmc</groupId>
@@ -173,12 +177,28 @@
                 <version>1.16.5-R0.1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>com.comphenix.protocol</groupId>
+                <artifactId>ProtocolLib</artifactId>
+                <version>4.6.0-SNAPSHOT</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!-- Libraries -->
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
-                <artifactId>padla</artifactId>
+                <artifactId>java-commons</artifactId>
                 <version>${version.padla}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis</groupId>
+                <artifactId>ultimate-messenger</artifactId>
+                <version>${version.padla}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis.minecraft</groupId>
+                <artifactId>packet-wrapper</artifactId>
+                <version>1.16.4-SNAPSHOT</version>
             </dependency>
 
             <!-- Code-generation -->
@@ -198,6 +218,97 @@
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
+
+            <!-- Testing -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.7.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>3.7.7</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>build-extras</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sign-artifacts</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sonatype-ossrh-deployment-auto-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>sonatype-ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/zaraza-common-api/pom.xml
+++ b/zaraza-common-api/pom.xml
@@ -21,17 +21,51 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>zaraza-common</artifactId>
+    <artifactId>zaraza-common-api</artifactId>
 
     <dependencies>
+        <!-- Runtime -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+        </dependency>
 
+        <!-- Libraries -->
+        <dependency>
+            <groupId>ru.progrm-jarvis.minecraft</groupId>
+            <artifactId>packet-wrapper</artifactId>
+        </dependency>
+
+        <!-- Libraries -->
+        <dependency>
+            <groupId>ru.progrm-jarvis</groupId>
+            <artifactId>ultimate-messenger</artifactId>
+        </dependency>
+
+        <!-- Code-generation -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+        </dependency>
+
+        <!-- Annotations -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/annotation/BukkitService.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/annotation/BukkitService.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Marker indicating that this target should be provided at runtime as a {@link org.bukkit.Bukkit Bukkit} service
+ * available via {@link org.bukkit.plugin.ServicesManager service manager}.
+ */
+// non-inherited and default retention is correct
+@Documented
+@Target(ElementType.TYPE)
+public @interface BukkitService {
+
+    /**
+     * Gets the dependency names which is required for the annotated service to be available.
+     *
+     * @return required dependency names
+     */
+    String[] value() default {};
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/FlowProcessors.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/FlowProcessors.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.flow;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Flow.Processor;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+
+/**
+ * Utilities related to {@link Processor}.
+ */
+@UtilityClass
+public class FlowProcessors {
+
+    /**
+     * Creates a new thread-unsafe {@link Processor processor}.
+     *
+     * @param <T> type of processed values
+     *
+     * @return created {@link Processor processor}
+     */
+    public <T> @NotNull Processor<T, T> createProcessor() {
+        return new ThreadUnsafeProcessor<>(new HashSet<>());
+    }
+
+    /**
+     * Creates a new thread-unsafe {@link Processor processor}.
+     *
+     * @param <T> type of processed values
+     *
+     * @return created {@link Processor processor}
+     */
+    public <T> @NotNull MemoizingFlowProcessor<T, T> createMemoizingProcessor() {
+        return new MemoizingThreadUnsafeProcessor<>(new HashSet<>());
+    }
+
+    /**
+     * Simple {@link Processor processor} for which no concurrency guarantees are given.
+     *
+     * @param <T> type of processed values
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static class ThreadUnsafeProcessor<T> implements Processor<T, T> {
+
+        /**
+         * All subscribers of this processor
+         */
+        @NotNull Set<@NotNull Subscriber<? super T>> subscribers;
+
+        @Override
+        public void subscribe(final Subscriber<? super T> subscriber) {
+            if (subscribers.add(subscriber)) subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long amount) {} // no-op
+
+                @Override
+                public void cancel() {
+                    subscribers.remove(subscriber);
+                }
+            });
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {} // no-op
+
+        @Override
+        public void onNext(final T item) {
+            for (val subscriber : subscribers) subscriber.onNext(item);
+        }
+
+        @Override
+        public void onError(final Throwable error) {
+            for (val subscriber : subscribers) subscriber.onError(error);
+        }
+
+        @Override
+        public void onComplete() {
+            for (val subscriber : subscribers) subscriber.onComplete();
+        }
+    }
+
+    /**
+     * {@link MemoizingFlowProcessor Memoizing} {@link ThreadUnsafeProcessor}.
+     *
+     * @param <T> type of processed values
+     */
+    @Accessors(fluent = true)
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    private static final class MemoizingThreadUnsafeProcessor<T>
+            extends ThreadUnsafeProcessor<T> implements MemoizingFlowProcessor<T, T> {
+
+        /**
+         * Last value passed to {@link #onNext(Object)}.
+         */
+        @Getter @Nullable T lastValue; // default-initialized to null
+
+        private MemoizingThreadUnsafeProcessor(final @NotNull Set<@NotNull Subscriber<? super T>> subscribers) {
+            super(subscribers);
+        }
+
+        @Override
+        public void onNext(final T item) {
+            super.onNext(lastValue = item);
+        }
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/FlowSubscribers.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/FlowSubscribers.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.flow;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.function.Consumer;
+
+/**
+ * Utilities related to {@link Subscriber}.
+ */
+@UtilityClass
+public class FlowSubscribers {
+
+    /**
+     * Creates a new subscriber.
+     *
+     * @param nextHandler handler to be notified when {@link Flow.Subscriber#onNext(Object)} gets called
+     * @param errorHandler handler to be notified when {@link Flow.Subscriber#onError(Throwable)} gets called
+     * @param <T> type of value whose updates will be listened
+     * @return created subscriber
+     *
+     * @throws NullPointerException if {@code nextHandler} is {@code null}
+     * @throws NullPointerException if {@code errorHandler} is {@code null}
+     */
+    public <T> @NotNull Subscriber<T> createSubscriber(
+            final @NonNull Consumer<? super T> nextHandler,
+            final @NonNull Consumer<@NotNull Throwable> errorHandler
+    ) {
+        return new DelegatingSubscriber<>(nextHandler, errorHandler);
+    }
+
+    /**
+     * Creates a new subscriber with re-throwing error handler.
+     *
+     * @param nextHandler handler to be notified when {@link Flow.Subscriber#onNext(Object)} gets called
+     * @param <T> type of value whose updates will be listened
+     * @return created subscriber
+     *
+     * @throws NullPointerException if {@code nextHandler} is {@code null}
+     */
+    public <@NotNull T> @NotNull Subscriber<T> createSubscriber(
+            final Consumer<@NotNull T> nextHandler
+    ) {
+        return createSubscriber(nextHandler, error -> {
+            throw new InternalError("An unexpected error was passed to ChangeListener", error);
+        });
+    }
+
+    /**
+     * Creates a new thread-unsafe subscriber.
+     *
+     * @param nextHandler handler to be notified when {@link Flow.Subscriber#onNext(Object)} gets called
+     * @param errorHandler handler to be notified when {@link Flow.Subscriber#onError(Throwable)} gets called
+     * @param <T> type of value whose updates will be listened
+     * @return created memoizing subscriber
+     *
+     * @throws NullPointerException if {@code nextHandler} is {@code null}
+     * @throws NullPointerException if {@code errorHandler} is {@code null}
+     */
+    public <T> @NotNull MemoizingFlowSubscriber<T> createMemoizingSubscriber(
+            final @NonNull Consumer<? super T> nextHandler,
+            final @NonNull Consumer<@NotNull Throwable> errorHandler
+    ) {
+        return new ThreadUnsafeMemoizingDelegatingSubscriber<>(nextHandler, errorHandler);
+    }
+
+    /**
+     * Creates a new thread-unsafe memoizing subscriber with re-throwing error handler.
+     *
+     * @param nextHandler handler to be notified when {@link Flow.Subscriber#onNext(Object)} gets called
+     * @param <T> type of value whose updates will be listened
+     * @return created memoizing subscriber
+     *
+     * @throws NullPointerException if {@code nextHandler} is {@code null}
+     */
+    public <@NotNull T> @NotNull MemoizingFlowSubscriber<T> createMemoizingSubscriber(
+            final Consumer<? super @NotNull T> nextHandler
+    ) {
+        return createMemoizingSubscriber(nextHandler, error -> {
+            throw new InternalError("An unexpected error was passed to ChangeListener", error);
+        });
+    }
+
+    /**
+     * Creates a new thread-unsafe memoizing subscriber with no-op value handler and re-throwing error handler.
+     *
+     * @param <T> type of value whose updates will be listened
+     * @return created memoizing subscriber
+     */
+    public <@NotNull T> @NotNull MemoizingFlowSubscriber<T> createMemoizingSubscriber() {
+        return createMemoizingSubscriber(newValue -> {});
+    }
+
+    //<editor-fold desc="Inner implementations" defaultstate="collapsed">
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static class DelegatingSubscriber<T> implements Subscriber<T> {
+
+        @NotNull Consumer<? super T> nextHandler;
+        @NotNull Consumer<@NotNull Throwable> errorHandler;
+
+        @Override
+        public void onNext(final T item) {
+            nextHandler.accept(item);
+        }
+
+        @Override
+        public void onError(final Throwable error) {
+            errorHandler.accept(error);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {} // this one is usually unneeded
+
+        @Override
+        public void onComplete() {} // this one is usually unneeded
+    }
+
+    @Accessors(fluent = true)
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    private static final class ThreadUnsafeMemoizingDelegatingSubscriber<T>
+            extends DelegatingSubscriber<T> implements MemoizingFlowSubscriber<T> {
+
+        /**
+         * Last value passed to {@link #onNext(Object)}.
+         */
+        @Getter @Nullable T lastValue; // default-initialized to null
+
+        private ThreadUnsafeMemoizingDelegatingSubscriber(final @NotNull Consumer<? super T> nextHandler,
+                                                          final @NotNull Consumer<@NotNull Throwable> errorHandler) {
+            super(nextHandler, errorHandler);
+        }
+    }
+    //</editor-fold>
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/MemoizingFlowProcessor.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/MemoizingFlowProcessor.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.flow;
+
+import java.util.concurrent.Flow;
+
+/**
+ * {@link Flow.Processor} which memoizes its last processed value.
+ *
+ * @param <T> the subscribed item type
+ * @param <R> the published item type
+ */
+public interface MemoizingFlowProcessor<T, R> extends Flow.Processor<T, R>, MemoizingFlowSubscriber<T> {}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/MemoizingFlowSubscriber.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/MemoizingFlowSubscriber.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.flow;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.Flow;
+
+/**
+ * {@link Flow.Subscriber} storing the result of its last call to {@link #onNext(Object)}.
+ *
+ * @param <T> the subscribed item type
+ */
+public interface MemoizingFlowSubscriber<@NotNull T> extends Flow.Subscriber<@NotNull T> {
+
+    /**
+     * Gets the last {@link #onNext(Object) handled} value.
+     *
+     * @return the last passed value or {@code null} if there was none
+     */
+    @Nullable T lastValue();
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/package-info.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/flow/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities related to {@link java.util.concurrent.Flow}.
+ */
+package ru.divinecraft.zaraza.common.api.flow;

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/MutablePlayerSet.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/MutablePlayerSet.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+
+/**
+ * Mutable {@link Player set of players}.
+ */
+public interface MutablePlayerSet
+        extends PlayerSet, MutablePlayerSetMethods, Flow.Publisher<MutablePlayerSet.@NotNull Update> {
+
+    /**
+     * Removes the specified player from this set.
+     *
+     * @param player player removed from this set
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     */
+    boolean remove(@NotNull Player player);
+
+    /**
+     * Gets a {@link Set} view of this set of players.
+     *
+     * @return {@link Set} view of this player set
+     */
+    @NotNull Set<@NotNull Player> asSet();
+
+    /**
+     * Keeps only the specified players in set.
+     *
+     * @param players only players kept in this set
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     *
+     * @throws NullPointerException if {@code players} is {@code null}
+     */
+    boolean retainAll(@NonNull Collection<@NotNull Player> players);
+
+    /**
+     * Removes all specified players from this set.
+     *
+     * @param players players removed from this set
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     *
+     * @throws NullPointerException if {@code players} is {@code null}
+     */
+    boolean removeAll(@NonNull Collection<@NotNull Player> players);
+
+    @Override // this is required to resolve conflict with the same yet abstract method in PlayerSetMethods
+    void forEach(@NonNull Consumer<? super @NotNull Player> action);
+
+    /**
+     * Update event of a {@link PlayerSet set of players}
+     */
+    interface Update {
+
+        /**
+         * Gets the action performed by this update.
+         *
+         * @return action performed by this update
+         */
+        @Contract(pure = true)
+        @NotNull Action action();
+
+        /**
+         * Gets the updated players.
+         *
+         * @return updated players
+         */
+        @Contract(pure = true)
+        @NotNull PlayerSet players();
+
+        /**
+         * Creates a new player set update with the given values.
+         *
+         * @param action action performed by this update
+         * @param players the updated players
+         * @return created player set update
+         */
+        static @NotNull Update create(final @NotNull Action action, final @NotNull PlayerSet players) {
+            return new SimpleUpdate(action, players);
+        }
+
+        /**
+         * Action of a {@link Update player set update}
+         */
+        enum Action {
+            /**
+             * Addition to the set.
+             */
+            ADD,
+            /**
+             * Removal from the set.
+             */
+            REMOVE
+        }
+    }
+
+    /**
+     * Simple implementation of {@link Update player set update}.
+     */
+    @Value
+    @Accessors(fluent = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    class SimpleUpdate implements Update {
+
+        /**
+         * The action performed by this update.
+         */
+        @NotNull Update.Action action;
+
+        /**
+         * The updated player
+         */
+        @NotNull PlayerSet players;
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/MutablePlayerSetMethods.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/MutablePlayerSetMethods.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import lombok.NonNull;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * This is a super-interface of {@link MutablePlayerSet}
+ * representing its methods overlapping with {@link java.util.Set}.
+ */
+public interface MutablePlayerSetMethods extends PlayerSetMethods, Iterable<@NotNull Player> {
+
+    /**
+     * Clears this set.
+     */
+    void clear();
+
+    /**
+     * Adds the specified player to this set.
+     *
+     * @param player player added to this set
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     */
+    boolean add(@NotNull Player player);
+
+    /**
+     * Adds all specified players to this set.
+     *
+     * @param players players added to this set
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     *
+     * @throws NullPointerException if {@code players} is {@code null}
+     */
+    boolean addAll(@NonNull Collection<? extends Player> players);
+
+    /**
+     * Removes all players for which the filter returns {@code true}.
+     *
+     * @param filter filter checking which players to remove
+     * @return {@code true} if this set changed as the result of this call and {@code false} otherwise
+     *
+     * @throws NullPointerException if {@code filter} is {@code null}
+     */
+    boolean removeIf(@NonNull Predicate<? super @NotNull Player> filter);
+
+    @Override // this is required to resolve conflict with the same yet abstract method in PlayerSetMethods
+    @NotNull Spliterator<@NotNull Player> spliterator();
+
+    @Override // this is required to resolve conflict with the same yet abstract method in PlayerSetMethods
+    void forEach(@NonNull Consumer<? super @NotNull Player> action);
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSet.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSet.java
@@ -1,0 +1,545 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import com.google.common.collect.UnmodifiableIterator;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Set of {@link Player players}.
+ */
+public interface PlayerSet extends PlayerSetMethods {
+
+    /**
+     * Comparator which should be used for comparison of {@link Player players} by {@link PlayerSet player sets}.
+     */
+    Comparator<@NotNull Player> PLAYER_COMPARATOR = Comparator
+            .<Player>comparingLong(player -> player.getUniqueId().getMostSignificantBits())
+            .thenComparingLong(player -> player.getUniqueId().getLeastSignificantBits());
+
+    /**
+     * Gets the {@link Object#hashCode() hash code}  for the given player set
+     * as specified by {@link Set#hashCode()}.
+     *
+     * @param playerSet set of players for which to compute the hash code
+     * @return computed hash code
+     */
+    static int hashCodeOf(final @NotNull PlayerSet playerSet) {
+        var hashCode = 0;
+        for (final var enumeration = playerSet.enumeration(); enumeration.hasMoreElements(); ) hashCode
+                += enumeration.nextElement().hashCode();
+
+        return hashCode;
+    }
+
+    /**
+     * Compares the contents of the given player sets returning {@code true} if and only if they are the same.
+     *
+     * @param left first compared player set
+     * @param right second compared player set
+     * @return {@code true} if contents are equal and {@code false} otherwise
+     */
+    static boolean contentsEqual(final @NotNull PlayerSet left, final @NotNull PlayerSet right) {
+        if (left.size() != right.size()) return false;
+
+        for (final var enumeration = left.enumeration(); enumeration.hasMoreElements(); ) if (
+                !right.contains(enumeration.nextElement())) return false;
+
+        return true;
+    }
+
+    /**
+     * Checks if this set contains the given player.
+     *
+     * @param player player to check for containment in this set
+     * @return {@code true} if the given player is contained by this set and {@code false} otherwise
+     */
+    boolean contains(@NotNull Player player);
+
+    /**
+     * Creates an array containing the players currently contained by this player set.
+     *
+     * @return array of currently contained players
+     */
+    @NotNull Player @NotNull [] toArray();
+
+    /**
+     * Checks if this set contains all the players contained by {@code players}.
+     *
+     * @param players players to check for containment in this set
+     * @return {@code true} if all given players are contained by this set and {@code false} otherwise
+     */
+    boolean containsAll(@NonNull Collection<@NotNull Player> players);
+
+    /**
+     * Gets an unmodifiable {@link Set} view of this set of players.
+     *
+     * @return unmodifiable {@link Set} view of this player set
+     */
+    @NotNull @UnmodifiableView Set<@NotNull Player> asUnmodifiableSet();
+
+    /**
+     * Creates an {@link Enumeration enumeration} over this set's {@link Player players}.
+     *
+     * @return {@link Enumeration enumeration} over this set's {@link Player players}
+     */
+    @NotNull Enumeration<@NotNull Player> enumeration();
+
+    /**
+     * Creates an {@link UnmodifiableIterator unmodifiable iterator} over this set's {@link Player players}.
+     *
+     * @return {@link UnmodifiableIterator unmodifiable iterator} over this set's {@link Player players}
+     */
+    @NotNull UnmodifiableIterator<@NotNull Player> unmodifiableIterator();
+
+    /**
+     * Creates a new player set consisting of the given player.
+     *
+     * @param player the only player to be contained by the given player set
+     * @return created player set
+     *
+     * @throws NullPointerException of {@code player} is null
+     */
+    static @NotNull PlayerSet of(final @NonNull Player player) {
+        return new SinglePlayerSet(player);
+    }
+
+    /**
+     * Creates a new player set consisting of the given players.
+     *
+     * @param players collection of players which will be stored in the given set
+     * @return created player set
+     *
+     * @apiNote the behaviour is undefined if {@code players} is not distinct
+     */
+    static @NotNull PlayerSet of(final @NonNull @Unmodifiable Collection<? extends @NotNull Player> players) {
+        return of(players.toArray(Player[]::new));
+    }
+
+    /**
+     * Creates a new player set consisting of the given players
+     * assuming that {@code players} does not get mutated while created player set is accessed.
+     *
+     * @param players array of players which will be stored in the given set
+     * @return created player set
+     *
+     * @apiNote the behaviour is undefined if {@code players} is not distinct
+     * @apiNote the behaviour is undefined if any method of the created set
+     * gets called after mutation of {@code players}
+     */
+    static @NotNull PlayerSet of(final @NotNull Player @NonNull @Unmodifiable ... players) {
+        if (players.length == 1) return new SinglePlayerSet(players[0]);
+
+        Arrays.sort(players, PLAYER_COMPARATOR);
+
+        return new ArrayBasedPlayerSet(players);
+    }
+
+    /**
+     * Creates a new player set consisting of the given players.
+     *
+     * @param players array of players which will copied to the created player set
+     * @return created player set
+     */
+    static @NotNull PlayerSet ofCopy(final @NotNull Player @NonNull @Unmodifiable [] players) {
+        return of(players.clone());
+    }
+
+    /**
+     * Creates a new player set consisting of the given players assuming that {@code players}
+     * is {@link #PLAYER_COMPARATOR ordered} and does not get mutated while created player set is accessed.
+     *
+     * @param players array of players which will be stored in the given set
+     * @return created player set
+     *
+     * @apiNote the behaviour is undefined if {@code players} is not {@link #PLAYER_COMPARATOR ordered}
+     * @apiNote the behaviour is undefined if any method of the created set
+     * gets called after mutation of {@code players}
+     */
+    static @NotNull PlayerSet ofSorted(final @NotNull Player @NonNull @Unmodifiable [] players) {
+        if (players.length == 1) return new SinglePlayerSet(players[0]);
+
+        return new ArrayBasedPlayerSet(players);
+    }
+
+    /**
+     * Creates a new player set consisting of the given players assuming that {@code players}
+     * is {@link #PLAYER_COMPARATOR ordered}.
+     *
+     * @param players array of players which will be stored in the given set
+     * @return created player set
+     *
+     * @apiNote the behaviour is undefined if {@code players} is not {@link #PLAYER_COMPARATOR ordered}
+     */
+    static @NotNull PlayerSet ofSortedCopy(final @NotNull Player @NonNull [] players) {
+        return ofSorted(players.clone());
+    }
+
+    /**
+     * Creates a new player set consisting of the given players assuming that {@code players}
+     * is {@link #PLAYER_COMPARATOR ordered}.
+     *
+     * @param players collection of players which will be stored in the given set
+     * @return created player set
+     *
+     * @apiNote the behaviour is undefined if {@code players} is not distinct
+     */
+    static @NotNull PlayerSet ofSorted(final @NonNull @Unmodifiable Collection<? extends @NotNull Player> players) {
+        return of(players.toArray(Player[]::new));
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    final class SinglePlayerSet implements PlayerSet {
+
+        /**
+         * The only player contained by this player set
+         */
+        @NotNull Player player;
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public boolean contains(final @NotNull Player player) {
+            return this.player.equals(player);
+        }
+
+        @Override
+        public @NotNull Player @NotNull [] toArray() {
+            return new Player[]{player};
+        }
+
+        @Override
+        public boolean containsAll(@NonNull final Collection<@NotNull Player> players) {
+            return players.size() == 1 && player.equals(players.iterator().next());
+        }
+
+        @Override
+        public @NotNull @UnmodifiableView Set<@NotNull Player> asUnmodifiableSet() {
+            return Set.of(player);
+        }
+
+        @Override
+        public @NotNull Enumeration<@NotNull Player> enumeration() {
+            return new SimpleEnumeration();
+        }
+
+        @Override
+        public @NotNull UnmodifiableIterator<@NotNull Player> unmodifiableIterator() {
+            return new SimpleIterator();
+        }
+
+        @Override
+        public @NotNull Spliterator<@NotNull Player> spliterator() {
+            return new SimpleSpliterator();
+        }
+
+        @Override
+        public @NotNull Stream<@NotNull Player> stream() {
+            return Stream.of(player);
+        }
+
+        @Override
+        public @NotNull Stream<@NotNull Player> parallelStream() {
+            return Stream.of(player);
+        }
+
+        @Override
+        public void forEach(final @NonNull Consumer<? super @NotNull Player> action) {
+            action.accept(player);
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) return true;
+            if (!(other instanceof PlayerSet)) return false;
+
+            final PlayerSet playerSet;
+            return (playerSet = (PlayerSet) other).size() == 1
+                    && player.equals(playerSet.enumeration().nextElement());
+        }
+
+        @Override
+        public int hashCode() {
+            return player.hashCode();
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @FieldDefaults(level = AccessLevel.PRIVATE)
+        private final class SimpleEnumeration implements Enumeration<@NotNull Player> {
+
+            /**
+             * Flag indicating if {@link #nextElement()} was called
+             */
+            boolean wasUsed; // default-initialized to false
+
+            @Override
+            public boolean hasMoreElements() {
+                return !wasUsed;
+            }
+
+            @Override
+            public @NotNull Player nextElement() {
+                if (wasUsed) throw new NoSuchElementException(
+                        "There is no more elements available via this PlayerSet iterator"
+                );
+                wasUsed = true;
+
+                return player;
+            }
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @FieldDefaults(level = AccessLevel.PRIVATE)
+        private final class SimpleIterator extends UnmodifiableIterator<@NotNull Player> {
+
+            /**
+             * Flag indicating if {@link #next()} was called
+             */
+            boolean wasUsed; // default-initialized to false
+
+            @Override
+            public boolean hasNext() {
+                return !wasUsed;
+            }
+
+            @Override
+            public @NotNull Player next() {
+                if (wasUsed) throw new NoSuchElementException(
+                        "There is no more elements available via this PlayerSet iterator"
+                );
+                wasUsed = true;
+
+                return player;
+            }
+
+            @Override
+            public void forEachRemaining(final Consumer<? super @NotNull Player> action) {
+                if (!wasUsed) {
+                    wasUsed = true;
+                    action.accept(player);
+                }
+            }
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @FieldDefaults(level = AccessLevel.PRIVATE)
+        private final class SimpleSpliterator implements Spliterator<@NotNull Player> {
+
+            private static final int ALL_SPLITERATOR_CHARACTERISTICS
+                    = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.SIZED
+                    | Spliterator.NONNULL | Spliterator.IMMUTABLE | Spliterator.SUBSIZED | Spliterator.CONCURRENT;
+
+            boolean wasUsed; // default-initialized to false
+
+            @Override
+            public boolean tryAdvance(final Consumer<? super @NotNull Player> action) {
+                if (wasUsed) return false;
+
+                wasUsed = true;
+                action.accept(player);
+
+                return true;
+            }
+
+            @Override
+            public void forEachRemaining(final Consumer<? super @NotNull Player> action) {
+                if (!wasUsed) {
+                    wasUsed = true;
+                    action.accept(player);
+                }
+            }
+
+            @Override
+            public @Nullable Spliterator<@NotNull Player> trySplit() {
+                return null /* cannot be split */;
+            }
+
+            @Override
+            public long estimateSize() {
+                return wasUsed ? 0 : 1;
+            }
+
+            @Override
+            public long getExactSizeIfKnown() {
+                return wasUsed ? 0 : 1;
+            }
+
+            @Override
+            public int characteristics() {
+                return Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.SIZED
+                        | Spliterator.NONNULL | Spliterator.IMMUTABLE | Spliterator.SUBSIZED | Spliterator.CONCURRENT;
+            }
+
+            @Override
+            public boolean hasCharacteristics(final int characteristics) {
+                return (ALL_SPLITERATOR_CHARACTERISTICS & characteristics) == characteristics;
+            }
+
+            @Override
+            public @Nullable Comparator<? super @NotNull Player> getComparator() {
+                return PLAYER_COMPARATOR;
+            }
+        }
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    final class ArrayBasedPlayerSet implements PlayerSet {
+
+        // should be sorted
+        @NotNull Player @NotNull [] array;
+
+        @Override
+        public int size() {
+            return array.length;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return array.length == 0;
+        }
+
+        @Override
+        public boolean contains(@NotNull final Player player) {
+            return false;
+        }
+
+        @Override
+        public @NotNull Player @NotNull [] toArray() {
+            return array.clone();
+        }
+
+        @Override
+        public boolean containsAll(@NonNull final Collection<@NotNull Player> players) {
+            for (val player : players) if (Arrays.binarySearch(array, player, PLAYER_COMPARATOR) < 0) return false;
+            return true;
+        }
+
+        @Override
+        public @NotNull @UnmodifiableView Set<@NotNull Player> asUnmodifiableSet() {
+            return Set.of(array);
+        }
+
+        @Override
+        public @NotNull Enumeration<@NotNull Player> enumeration() {
+            return new SimpleEnumeration();
+        }
+
+        @Override
+        public @NotNull UnmodifiableIterator<@NotNull Player> unmodifiableIterator() {
+            return new SimpleIterator();
+        }
+
+        @Override
+        public @NotNull Spliterator<@NotNull Player> spliterator() {
+            return Spliterators.spliterator(array, Spliterator.IMMUTABLE | Spliterator.ORDERED);
+        }
+
+        @Override
+        public @NotNull Stream<@NotNull Player> stream() {
+            return StreamSupport.stream(spliterator(), false);
+        }
+
+        @Override
+        public @NotNull Stream<@NotNull Player> parallelStream() {
+            return StreamSupport.stream(spliterator(), true);
+        }
+
+        @Override
+        public void forEach(final @NonNull Consumer<? super @NotNull Player> action) {
+            for (val player : array) action.accept(player);
+        }
+
+        @Override
+        public boolean equals(final @Nullable Object other) {
+            return other == this || other instanceof PlayerSet && contentsEqual(this, (PlayerSet) other);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCodeOf(this);
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @FieldDefaults(level = AccessLevel.PRIVATE)
+        private final class SimpleEnumeration implements Enumeration<@NotNull Player> {
+
+            int nextIndex; // default-initialized to 0
+
+            @Override
+            public boolean hasMoreElements() {
+                return nextIndex < array.length;
+            }
+
+            @Override
+            public @NotNull Player nextElement() {
+                final int index;
+                if ((index = nextIndex++) >= array.length) throw new NoSuchElementException(
+                        "There is no more elements available via this PlayerSet iterator");
+
+                return array[index];
+            }
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @FieldDefaults(level = AccessLevel.PRIVATE)
+        private final class SimpleIterator extends UnmodifiableIterator<@NotNull Player> {
+
+            int nextIndex; // default-initialized to 0
+
+            @Override
+            public boolean hasNext() {
+                return nextIndex < array.length;
+            }
+
+            @Override
+            public @NotNull Player next() {
+                final int index;
+                if ((index = nextIndex++) >= array.length) throw new NoSuchElementException(
+                        "There is no more elements available via this PlayerSet iterator");
+
+                return array[index];
+            }
+
+            @Override
+            public void forEachRemaining(final Consumer<? super @NotNull Player> action) {
+                final Player[] thisArray;
+                val length = (thisArray = array).length;
+                for (var i = 0; i < length; i++) action.accept(thisArray[i]);
+                nextIndex = length;
+            }
+        }
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSetMethods.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSetMethods.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import lombok.NonNull;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * This is a super-interface of {@link PlayerSet}
+ * representing its methods overlapping with {@link java.util.Set}.
+ */
+public interface PlayerSetMethods {
+
+    /**
+     * Gets the size of this set of players.
+     *
+     * @return size of this set of players
+     */
+    int size();
+
+    /**
+     * Checks if this set is empty.
+     *
+     * @return {@code true} if this set os empty and {@code false} otherwise
+     */
+    boolean isEmpty();
+
+    /**
+     * Creates a {@link Spliterator spliterator} over this set's {@link Player players}.
+     *
+     * @return {@link Spliterator spliterator} over this set's {@link Player players}
+     */
+    @NotNull Spliterator<@NotNull Player> spliterator();
+
+    /**
+     * Creates a {@link Stream stream} over this set's {@link Player players}.
+     *
+     * @return {@link Stream stream} over this set's {@link Player players}
+     */
+    @NotNull Stream<@NotNull Player> stream();
+
+    /**
+     * Creates a parallel {@link Stream stream} over this set's {@link Player players}.
+     *
+     * @return parallel {@link Stream stream} over this set's {@link Player players}
+     */
+    @NotNull Stream<@NotNull Player> parallelStream();
+
+    /**
+     * Applies the given action to each element of this set.
+     *
+     *  @param action action to be applied to each element of this set
+     *
+     * @throws NullPointerException if {@code action} is {@code null}
+     */
+    void forEach(@NonNull Consumer<? super @NotNull Player> action);
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSets.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerSets.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import com.google.common.collect.UnmodifiableIterator;
+import lombok.*;
+import lombok.experimental.Delegate;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+import lombok.experimental.UtilityClass;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
+import ru.divinecraft.zaraza.common.api.flow.FlowProcessors;
+import ru.divinecraft.zaraza.common.api.player.MutablePlayerSet.Update;
+
+import java.util.*;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static ru.divinecraft.zaraza.common.api.player.MutablePlayerSet.Update.Action.ADD;
+import static ru.divinecraft.zaraza.common.api.player.MutablePlayerSet.Update.Action.REMOVE;
+
+/**
+ * Helper methods for {@link PlayerSet player sets}.
+ */
+@UtilityClass
+public class PlayerSets {
+
+    /**
+     * Empty array of {@link Player players}.
+     */
+    private static final @NotNull Player @NotNull [] EMPTY_PLAYER_ARRAY = new Player[0];
+
+    /**
+     * Wraps the given {@link Set} of {@link Player players} into a {@link PlayerSet player set}.
+     *
+     * @param set set to be wrapped
+     * @return wrapped {@link Set} of {@link Player players}
+     *
+     * @apiNote the behaviour of the created set's methods is undefined if the original set gets mutated
+     */
+    public @NotNull PlayerSet wrapToPlayerSet(final @NonNull @Unmodifiable Set<@NotNull Player> set) {
+        return new UncheckedPlayerSetWrapper(set);
+    }
+
+    /**
+     * Creates a new {@link MutablePlayerSet mutable player set}.
+     *
+     * @return newly created player set
+     */
+    public @NotNull MutablePlayerSet newMutablePlayerSet() {
+        return DelegatingMutablePlayerSet.wrap(new HashSet<>());
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class UncheckedPlayerSetWrapper implements PlayerSet {
+
+        @Delegate(types = {Iterable.class, PlayerSetMethods.class, MutablePlayerSetMethods.class})
+        @NotNull @Unmodifiable Set<@NotNull Player> set;
+
+        @Override
+        public boolean contains(@NotNull final Player player) {
+            return set.contains(player);
+        }
+
+        @Override
+        public @NotNull Player @NotNull [] toArray() {
+            return set.toArray(EMPTY_PLAYER_ARRAY);
+        }
+
+        @Override
+        public boolean containsAll(final @NonNull Collection<@NotNull Player> players) {
+            return set.containsAll(players);
+        }
+
+        @Override
+        public @NotNull @UnmodifiableView Set<@NotNull Player> asUnmodifiableSet() {
+            return set;
+        }
+
+        @Override
+        public @NotNull Enumeration<@NotNull Player> enumeration() {
+            return Collections.enumeration(set);
+        }
+
+        @Override
+        public @NotNull UnmodifiableIterator<@NotNull Player> unmodifiableIterator() {
+            return new UnmodifiablePlayerIterator(set.iterator());
+        }
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true) // TODO efficient bulk operations (publish Sets)
+    private static final class PublishingPlayerSetWrapper extends AbstractSet<@NotNull Player> {
+
+        /**
+         * {@link Set Set} to which all root operations are delegated
+         */
+        @Delegate(types = PlayerSetMethods.class)
+        @NotNull Set<@NotNull Player> set;
+
+        /**
+         * Subscriber to which all updates get published
+         */
+        @NotNull Flow.Subscriber<@NotNull Update> subscriber;
+
+        // Non-generic non-mutating operations
+
+        @Override
+        public boolean contains(final Object entry) {
+            return set.contains(entry);
+        }
+
+        @Override
+        public boolean containsAll(final @NotNull Collection<?> entries) {
+            return set.containsAll(entries);
+        }
+
+        @Override
+        public @NotNull Object @NotNull [] toArray() {
+            return set.toArray();
+        }
+
+        @Override
+        public <T> @NotNull T @NotNull [] toArray(final @NonNull T[] array) {
+            //noinspection SuspiciousToArrayCall: verified aboce
+            return set.toArray(array);
+        }
+
+        // Basic mutating operations
+
+        @Override
+        public @NotNull Iterator<@NotNull Player> iterator() {
+            return new PublishingPlayerIterator(set.iterator(), subscriber);
+        }
+
+        @Override
+        public boolean add(final @NotNull Player player) {
+            final boolean updated;
+            if (updated = set.add(player)) subscriber.onNext(Update.create(ADD, PlayerSet.of(player)));
+
+            return updated;
+        }
+
+        @Override
+        public boolean remove(final Object entry) {
+            final boolean updated;
+            if (updated = set.remove(entry)) {
+                assert entry instanceof Player
+                        : "entry should be of type Player as it was remove from set of Players";
+                subscriber.onNext(Update.create(REMOVE, PlayerSet.of((Player) entry)));
+            }
+
+            return updated;
+        }
+
+        // Bulk operations
+
+        @Override
+        public boolean addAll(final @NonNull Collection<? extends @NotNull Player> added) {
+            SortedSet<Player> addedPlayers = null;
+            for (val entry : added) if (set.add(entry)) {
+                if (addedPlayers == null) addedPlayers = new TreeSet<>(PlayerSet.PLAYER_COMPARATOR);
+                addedPlayers.add(entry);
+            }
+
+            if (addedPlayers == null) return false;
+
+            subscriber.onNext(Update.create(ADD, PlayerSet.ofSorted(addedPlayers)));
+
+            return true;
+        }
+
+        @Override
+        public boolean removeIf(final @NonNull Predicate<? super @NotNull Player> filter) {
+            SortedSet<Player> removedPlayers = null;
+
+            for (final var iterator = set.iterator(); iterator.hasNext(); ) {
+                final Player player;
+                if (filter.test(player = iterator.next())) {
+                    iterator.remove();
+
+                    if (removedPlayers == null) removedPlayers = new TreeSet<>(PlayerSet.PLAYER_COMPARATOR);
+                    removedPlayers.add(player);
+                }
+            }
+
+            if (removedPlayers == null) return false;
+
+            subscriber.onNext(Update.create(REMOVE, PlayerSet.ofSorted(removedPlayers)));
+
+            return true;
+        }
+
+        @Override
+        @SuppressWarnings("SuspiciousMethodCalls") // the way this method works
+        public boolean removeAll(final @NonNull Collection<?> removed) {
+            SortedSet<Player> removedPlayers = null;
+
+            // use smaller collection for iteration
+            if (size() <= removed.size()) for (final var iterator = set.iterator(); iterator.hasNext(); ) {
+                final Player player;
+                if (removed.contains(player = iterator.next())) {
+                    iterator.remove();
+
+                    if (removedPlayers == null) removedPlayers = new TreeSet<>(PlayerSet.PLAYER_COMPARATOR);
+                    removedPlayers.add(player);
+                }
+            } else for (val entry : removed) if (set.remove(entry)) {
+                assert entry instanceof Player
+                        : "entry should be of type Player as it was removed from the set containing Players";
+
+                if (removedPlayers == null) removedPlayers = new TreeSet<>(PlayerSet.PLAYER_COMPARATOR);
+                removedPlayers.add((Player) entry);
+            }
+
+            if (removedPlayers == null) return false;
+
+            subscriber.onNext(Update.create(REMOVE, PlayerSet.ofSorted(removedPlayers)));
+
+            return true;
+        }
+
+        @Override
+        public boolean retainAll(final @NonNull Collection<?> kept) {
+            SortedSet<Player> removedPlayers = null;
+            for (final var iterator = set.iterator(); iterator.hasNext(); ) {
+                final Player player;
+                if (!kept.contains(player = iterator.next())) {
+                    iterator.remove();
+
+                    if (removedPlayers == null) removedPlayers = new TreeSet<>(PlayerSet.PLAYER_COMPARATOR);
+                    removedPlayers.add(player);
+                }
+            }
+
+            if (removedPlayers == null) return false;
+
+            subscriber.onNext(Update.create(REMOVE, PlayerSet.ofSorted(removedPlayers)));
+
+            return true;
+        }
+    }
+
+    /**
+     * {@link PlayerSet Player set} delegating storage logic to a {@link Set} of {@link Player players}.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class DelegatingMutablePlayerSet implements MutablePlayerSet {
+
+        /**
+         * {@link Set Set} to which all root operations are delegated
+         */
+        @Delegate(types = {Iterable.class, PlayerSetMethods.class, MutablePlayerSetMethods.class})
+        @NotNull Set<@NotNull Player> set;
+
+        /**
+         * {@link Flow.Publisher Publisher} of {@link Player players} to which all {@link Flow}
+         */
+        @Delegate(types = Flow.Publisher.class)
+        @NotNull Flow.Publisher<@NotNull Update> publisher;
+
+        /**
+         * Creates a new {@link PlayerSet player set} wrapping the given {@link Set} of {@link Player players}.
+         *
+         * @param set wrapped set of players
+         * @return created {@link PlayerSet player set}
+         */
+        public static @NotNull MutablePlayerSet wrap(final @NotNull Set<@NotNull Player> set) {
+            final Flow.Processor<@NotNull Update, @NotNull Update> processor;
+            return new DelegatingMutablePlayerSet(
+                    new PublishingPlayerSetWrapper(set, processor = FlowProcessors.createProcessor()), processor
+            );
+        }
+
+        // Methods of PlayerSet unavailable via PlayerSetMethods
+
+        @Override
+        public boolean contains(@NotNull final Player player) {
+            return set.contains(player);
+        }
+
+        @Override
+        public @NotNull Player @NotNull [] toArray() {
+            return set.toArray(Player[]::new);
+        }
+
+        @Override
+        public boolean containsAll(final @NonNull Collection<@NotNull Player> players) {
+            return set.containsAll(players);
+        }
+
+        // Methods of MutablePlayerSet unavailable via MutablePlayerSetMethods
+
+        @Override
+        public boolean remove(@NotNull final Player player) {
+            return set.remove(player);
+        }
+
+        @Override
+        public boolean retainAll(final @NonNull Collection<@NotNull Player> players) {
+            return set.retainAll(players);
+        }
+
+        @Override
+        public boolean removeAll(final @NonNull Collection<@NotNull Player> players) {
+            return set.removeAll(players);
+        }
+
+        // Conversions to unmodifiable views
+
+        @Override
+        public @NotNull @UnmodifiableView Set<@NotNull Player> asUnmodifiableSet() {
+            return Collections.unmodifiableSet(set);
+        }
+
+        @Override
+        public @NotNull Enumeration<@NotNull Player> enumeration() {
+            return Collections.enumeration(set);
+        }
+
+        @Override
+        public @NotNull UnmodifiableIterator<@NotNull Player> unmodifiableIterator() {
+            return new UnmodifiablePlayerIterator(set.iterator());
+        }
+
+        // Conversion to modifiable view
+
+        @Override
+        @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType") // this is part of contract
+        public @NotNull Set<@NotNull Player> asSet() {
+            return set;
+        }
+    }
+
+    /**
+     * {@link Iterator Iterator} over {@link Player players} which does not permit any modification operations.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class UnmodifiablePlayerIterator extends UnmodifiableIterator<@NotNull Player> {
+
+        /**
+         * {@link Iterator Iterator} to which all read-logic is delegated
+         */
+        @NotNull Iterator<@NotNull Player> set;
+
+        @Override
+        public boolean hasNext() {
+            return set.hasNext();
+        }
+
+        @Override
+        public @NotNull Player next() {
+            return set.next();
+        }
+
+        @Override
+        public void forEachRemaining(final @NotNull Consumer<? super @NotNull Player> action) {
+            set.forEachRemaining(action);
+        }
+    }
+
+    /**
+     * {@link Iterator Iterator} over {@link Player players} publishing updates done via it to the specified subscriber.
+     */
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class PublishingPlayerIterator implements Iterator<@NotNull Player> {
+
+        /**
+         * {@link Iterator Iterator} to which all read-logic is delegated
+         */
+        @NotNull Iterator<@NotNull Player> set;
+
+        /**
+         * Subscriber being notified on modifications.
+         */
+        @NotNull Flow.Subscriber<@NotNull Update> subscriber;
+
+        @NonFinal @Nullable Player last;
+
+        @Override
+        public boolean hasNext() {
+            return set.hasNext();
+        }
+
+        @Override
+        public @NotNull Player next() {
+            return last = set.next();
+        }
+
+        @Override
+        public void remove() {
+            set.remove();
+
+            val thisLast = last;
+            assert thisLast != null : "last cannot be null as something was removed from iterator of non-null Players";
+
+            subscriber.onNext(Update.create(REMOVE, PlayerSet.of(thisLast)));
+        }
+
+        @Override
+        public void forEachRemaining(final @NotNull Consumer<? super @NotNull Player> action) {
+            set.forEachRemaining(action);
+        }
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerViewable.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerViewable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link PlayerViewed} whose players can be updated.
+ */
+@FunctionalInterface
+public interface PlayerViewable extends PlayerViewed {
+
+    @Override
+    @NotNull MutablePlayerSet viewers();
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerViewed.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/PlayerViewed.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An object which may be viewed by players.
+ */
+@FunctionalInterface // JFF
+public interface PlayerViewed {
+
+    /**
+     * Gets players viewing this object.
+     *
+     * @return players viewing this object
+     */
+    @Contract(pure = true)
+    @NotNull PlayerSet viewers();
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/package-info.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/player/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * General APIs related to {@link org.bukkit.entity.Player players}.
+ */
+package ru.divinecraft.zaraza.common.api.player;

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/MutableSidebar.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/MutableSidebar.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.sidebar;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.ultimatemessenger.format.model.TextModel;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Mutable {@link Sidebar sidebar}.
+ */
+public interface MutableSidebar<L extends MutableSidebar.@NotNull MutableLine> extends ViewableSidebar<L> {
+
+    @Override
+    @NotNull Flow.Processor<@NotNull TextModel<@NotNull Player>, @NotNull TextModel<@NotNull Player>> title();
+
+    /**
+     * Mutable {@link Sidebar.Line sidebar line}.
+     */
+    interface MutableLine extends Line {
+
+        @Override
+        @NotNull Flow.Processor<@NotNull TextModel<@NotNull Player>, @NotNull TextModel<@NotNull Player>> text();
+
+        @Override
+        @NotNull Flow.Processor<@NotNull Integer, @NotNull Integer> value();
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/Sidebar.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/Sidebar.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.sidebar;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import ru.divinecraft.zaraza.common.api.player.PlayerViewed;
+import ru.progrm_jarvis.ultimatemessenger.format.model.TextModel;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Dynamic {@link Player player} sidebar display.
+ */
+public interface Sidebar<L extends Sidebar.@NotNull Line> extends PlayerViewed {
+
+    /**
+     * Gets the title of this sidebar.
+     *
+     * @return title of this sidebar
+     */
+    @NotNull Flow.Publisher<@NotNull TextModel<@NotNull Player>> title();
+
+    /**
+     * Gets the lines of this sidebar.
+     *
+     * @return lines of this sidebar
+     */
+    @NotNull Lines<L> lines();
+
+    /**
+     * Line of {@link Sidebar sidebar}.
+     */
+    interface Line {
+
+        /**
+         * Gets the text of this line.
+         *
+         * @return text of this line
+         */
+        @NotNull Flow.Publisher<@NotNull TextModel<@NotNull Player>> text();
+
+        /**
+         * Gets the value of this line.
+         *
+         * @return value of this line
+         */
+        @NotNull Flow.Publisher<@NotNull Integer> value();
+    }
+
+    /**
+     * An immutable array of {@link Line sidebar lines}.
+     */
+    interface Lines<L extends @NotNull Line> extends Iterable<L> {
+
+        /**
+         * Gets the count of the lines.
+         *
+         * @return count of the lines
+         */
+        @Contract(pure = true)
+        int count();
+
+        /**
+         * Gets the line at the specified index.
+         *
+         * @param index index of the line
+         * @return line at the gicen index
+         *
+         * @throws IndexOutOfBoundsException if the index is negative or is greater
+         * or equal to the {@link #count() count}.
+         */
+        @Contract(pure = true)
+        @NotNull L at(int index);
+    }
+}
+

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/SidebarManager.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/SidebarManager.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.sidebar;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import ru.divinecraft.zaraza.common.api.annotation.BukkitService;
+import ru.progrm_jarvis.ultimatemessenger.format.model.TextModel;
+
+/**
+ * Manager of dynamic {@link Player player} sidebars.
+ */
+@BukkitService("ZarazaCommon")
+public interface SidebarManager {
+
+    /**
+     * Creates a new dynamic sidebar with the given title.
+     *
+     * @param title title of the created sidebar
+     * @return created sidebar
+     */
+    @NotNull MutableSidebar<@NotNull ?> createSidebar(@NotNull TextModel<@NotNull Player> title);
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/ViewableSidebar.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/ViewableSidebar.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.sidebar;
+
+import org.jetbrains.annotations.NotNull;
+import ru.divinecraft.zaraza.common.api.player.PlayerViewable;
+
+public interface ViewableSidebar<L extends Sidebar.@NotNull Line> extends Sidebar<L>, PlayerViewable {}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/package-info.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/sidebar/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * API for creating dynamic extensible {@link ru.divinecraft.zaraza.common.api.sidebar.Sidebar player sidebars}.
+ */
+package ru.divinecraft.zaraza.common.api.sidebar;

--- a/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/player/PlayerSetsTest.java
+++ b/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/player/PlayerSetsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.player;
+
+import lombok.NonNull;
+import lombok.val;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.concurrent.Flow;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.*;
+
+class PlayerSetsTest {
+
+    @SuppressWarnings("unchecked") // generic mock instantiation
+    private static @NotNull Flow.Subscriber<MutablePlayerSet.Update> mockSubscriber() {
+        return mock(Flow.Subscriber.class);
+    }
+
+    private static @NotNull Player playerMock(final @NonNull String name) {
+        val mock = mock(Player.class);
+
+        when(mock.getName()).thenReturn(name);
+        when(mock.getDisplayName()).thenReturn(name);
+        when(mock.getPlayerListName()).thenReturn(name);
+        when(mock.getCustomName()).thenReturn(name);
+
+        return mock;
+    }
+
+    @Test
+    void newMutablePlayerSet_onSubscribeGetsCalled() {
+        val subscriber = mockSubscriber();
+        val set = PlayerSets.newMutablePlayerSet();
+
+        set.subscribe(subscriber);
+        verify(subscriber, times(1)).onSubscribe(notNull());
+        verify(subscriber, times(0)).onNext(any());
+    }
+
+    @Test
+    void newMutablePlayerSet_subscriptionCancelDoesNotFail() {
+        val subscriber = mockSubscriber();
+        val set = PlayerSets.newMutablePlayerSet();
+
+        set.subscribe(subscriber);
+
+        val subscription = new Flow.Subscription[1];
+        verify(subscriber, times(1)).onSubscribe(argThat(newSubscription -> {
+            subscription[0] = newSubscription;
+
+            return newSubscription != null;
+        }));
+
+        assertDoesNotThrow((Executable) () -> subscription[0].cancel());
+    }
+
+    @Test
+    void newMutablePlayerSet_subscriptionIsSame() {
+        val subscriber = mockSubscriber();
+        val set = PlayerSets.newMutablePlayerSet();
+
+        set.subscribe(subscriber);
+        verify(subscriber, times(1)).onSubscribe(any());
+
+        set.subscribe(subscriber);
+        verify(subscriber, times(1)).onSubscribe(any());
+    }
+
+    @Test
+    void newMutablePlayerSet_correctSimpleLogic() {
+        val john = playerMock("John");
+        val jack = playerMock("Jack");
+        val bob = playerMock("Bob");
+        val joper = playerMock("Joper");
+
+        @SuppressWarnings("unchecked") final Flow.Subscriber<MutablePlayerSet.Update> subscriber
+                = mock(Flow.Subscriber.class);
+
+        val set = PlayerSets.newMutablePlayerSet();
+
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+        assertFalse(set.contains(john));
+        assertFalse(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+
+        // initial subscription
+        set.subscribe(subscriber);
+        verify(subscriber, times(1)).onSubscribe(notNull());
+        verify(subscriber, times(0)).onNext(any());
+        // obviously no changes to the size should happen
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+
+        set.add(john);
+        assertFalse(set.isEmpty());
+        assertEquals(1, set.size());
+        assertTrue(set.contains(john));
+        assertFalse(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+        verify(subscriber)
+                .onNext(eq(MutablePlayerSet.Update.create(MutablePlayerSet.Update.Action.ADD, PlayerSet.of(john))));
+
+        assertFalse(set.isEmpty());
+        assertEquals(1, set.size());
+        assertTrue(set.contains(john));
+        assertFalse(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+        // no extra publish should happen
+        verify(subscriber)
+                .onNext(eq(MutablePlayerSet.Update.create(MutablePlayerSet.Update.Action.ADD, PlayerSet.of(john))));
+
+        set.remove(john);
+        verify(subscriber)
+                .onNext(eq(MutablePlayerSet.Update.create(MutablePlayerSet.Update.Action.REMOVE, PlayerSet.of(john))));
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+        assertFalse(set.contains(john));
+        assertFalse(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+
+        set.add(jack);
+        verify(subscriber)
+                .onNext(eq(MutablePlayerSet.Update.create(MutablePlayerSet.Update.Action.ADD, PlayerSet.of(jack))));
+        assertFalse(set.isEmpty());
+        assertEquals(1, set.size());
+        assertFalse(set.contains(john));
+        assertTrue(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+
+        set.add(john);
+        verify(subscriber)
+                .onNext(eq(MutablePlayerSet.Update.create(MutablePlayerSet.Update.Action.ADD, PlayerSet.of(jack))));
+        assertFalse(set.isEmpty());
+        assertEquals(2, set.size());
+        assertTrue(set.contains(john));
+        assertTrue(set.contains(jack));
+        assertFalse(set.contains(bob));
+        assertFalse(set.contains(joper));
+    }
+}


### PR DESCRIPTION
# Description

This adds all commits from `master` to `development`.

# Changeset

<details>
<summary>Included commits</summary>

* chore: add Sidebar API package

* build: bump Java version to 11

* build: configure lazy usage of deployment-related plugins

* build(dep): fix initial dependency issues

* build(dep): use padla modules instead of parent

* build(dep): fix dependencies of zaraza-commons-api

* build: bump Java version to 11

* build: configure lazy usage of deployment-related plugins

* build(dep): use padla modules instead of parent

* build(dep): fix dependencies of zaraza-commons-api

* feat: implement API for Player sets

* build(dep): add testing dependencies

* test: test minimal PlayerSetsTest implementation

* feat: add effective bulk operations to PlayerSet

* docs: add missing documentation and methods to PlayerSet API

* feat: add PlayerViewed and PlayerViewable

* feat: add BukkitService annotation

* feat: implement Sidebar API

* build(dep): add protocol libraries

* build(dep): add ProtocolLib

* build(dep): add packet-wrapper

* build(dep): add aikar's repo as an alternative to dmulloy2's

* ci: bump Java version to 11 and remove redudndant CI build job

* ci: bump Java version to 11 and remove redundant CI build job

* build(dep): add own module to dependencyManagement

* feat: mark SidebarManager as a BukkitService

* build(dep): add own module to dependencyManagement

* build(dep): add own module to dependencyManagement

* docs: fix duplicated copyright header of Sidebar

* feat: add FlowProcessors

* chore: cleanup PlayerViewable mess

* chore: simplify generic bounds in Sidebar

* feat: extend Flow API with the concept of memoizing

* chore: use correct dependency name for SidebarManager

* fix: correct accessors in FLow factories
</details>