### PR TITLE
Remove no longer needed aikar's repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,6 @@
             <id>dmulloy2-repo</id>
             <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
         </repository>
-        <repository>
-            <id>aikar</id>
-            <url>http://repo.aikar.co/nexus/content/groups/aikar/</url>
-        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
# Description

This removes temporarily used aikar's Maven repository from `repositories`.