### PR TITLE
Bump ProtocolLib to version 4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>com.comphenix.protocol</groupId>
                 <artifactId>ProtocolLib</artifactId>
-                <version>4.6.0-SNAPSHOT</version>
+                <version>4.6.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
# Description

This updates `ProtocolLib`'s version to `4.6.0`.