### PR TITLE
Relocate fastutil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <version.zaraza>1.0.0-SNAPSHOT</version.zaraza>
         <zaraza.rootPackage>ru.divinecraft.zaraza</zaraza.rootPackage>
         <zaraza.libPackage>${zaraza.rootPackage}.lib</zaraza.libPackage>
+        <version.padla>1.0.0-SNAPSHOT</version.padla>
         <version.minecraft-utils>1.0.0-SNAPSHOT</version.minecraft-utils>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
@@ -37,6 +36,8 @@
         <github.url>https://github.com/${github.coordinate}</github.url>
         <!-- Dependency versions -->
         <version.zaraza>1.0.0-SNAPSHOT</version.zaraza>
+        <zaraza.rootPackage>ru.divinecraft.zaraza</zaraza.rootPackage>
+        <zaraza.libPackage>${zaraza.rootPackage}.lib</zaraza.libPackage>
         <version.padla>1.0.0-SNAPSHOT</version.padla>
         <version.minecraft-utils>1.0.0-SNAPSHOT</version.minecraft-utils>
     </properties>
@@ -122,6 +123,27 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.4</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <relocations>
+                            <relocation>
+                                <pattern>it.unimi.dsi.fastutil.</pattern>
+                                <shadedPattern>${zaraza.libPackage}.fastutil.</shadedPattern>
+                            </relocation>
+                        </relocations>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.2.0</version>
                     <configuration>
@@ -183,6 +205,11 @@
             </dependency>
 
             <!-- Libraries -->
+            <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil</artifactId>
+                <version>8.5.2</version>
+            </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>java-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,9 @@
         <github.coordinate>${github.owner}/${github.repository}</github.coordinate>
         <github.url>https://github.com/${github.coordinate}</github.url>
         <!-- Dependency versions -->
+        <version.zaraza>1.0.0-SNAPSHOT</version.zaraza>
         <version.padla>1.0.0-SNAPSHOT</version.padla>
+        <version.minecraft-utils>1.0.0-SNAPSHOT</version.minecraft-utils>
     </properties>
 
     <name>Zaraza</name>
@@ -161,9 +163,9 @@
         <dependencies>
             <!-- Own modules -->
             <dependency>
-                <groupId>${project.groupId}</groupId>
+                <groupId>ru.divinecraft</groupId>
                 <artifactId>zaraza-common-api</artifactId>
-                <version>${project.version}</version>
+                <version>${version.zaraza}</version>
             </dependency>
 
             <!-- Runtime -->
@@ -179,12 +181,6 @@
                 <version>4.6.0</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>io.sentry</groupId>
-                <artifactId>sentry</artifactId>
-                <version>4.2.0</version>
-                <scope>provided</scope>
-            </dependency>
 
             <!-- Libraries -->
             <dependency>
@@ -194,13 +190,33 @@
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
+                <artifactId>reflector</artifactId>
+                <version>${version.padla}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>ultimate-messenger</artifactId>
                 <version>${version.padla}</version>
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis.minecraft</groupId>
+                <artifactId>minecraft-commons</artifactId>
+                <version>${version.minecraft-utils}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis.minecraft</groupId>
+                <artifactId>fake-entity-lib</artifactId>
+                <version>${version.minecraft-utils}</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis.minecraft</groupId>
                 <artifactId>packet-wrapper</artifactId>
                 <version>1.16.4-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>4.2.0</version>
             </dependency>
 
             <!-- Code-generation -->

--- a/zaraza-common-api/pom.xml
+++ b/zaraza-common-api/pom.xml
@@ -33,20 +33,35 @@
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.sentry</groupId>
-            <artifactId>sentry</artifactId>
-        </dependency>
 
         <!-- Libraries -->
+        <dependency>
+            <groupId>ru.progrm-jarvis</groupId>
+            <artifactId>java-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ru.progrm-jarvis</groupId>
+            <artifactId>reflector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ru.progrm-jarvis</groupId>
+            <artifactId>ultimate-messenger</artifactId>
+        </dependency>
         <dependency>
             <groupId>ru.progrm-jarvis.minecraft</groupId>
             <artifactId>packet-wrapper</artifactId>
         </dependency>
-        <!-- Libraries -->
         <dependency>
-            <groupId>ru.progrm-jarvis</groupId>
-            <artifactId>ultimate-messenger</artifactId>
+            <groupId>ru.progrm-jarvis.minecraft</groupId>
+            <artifactId>minecraft-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ru.progrm-jarvis.minecraft</groupId>
+            <artifactId>fake-entity-lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
         </dependency>
 
         <!-- Code-generation -->


### PR DESCRIPTION
# Description

This enables relocation of `fastutil` which is used by `minecraft-utils` as its version is higher than that of Bukkit server.