### PR TITLE
Managed scheduler

### DIFF
--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/ManagedBukkitScheduler.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/ManagedBukkitScheduler.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.scheduler;
+
+import lombok.NonNull;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scheduler.BukkitWorker;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+/**
+ * Wrapper around {@link BukkitScheduler}
+ */
+public interface ManagedBukkitScheduler {
+
+    /**
+     * Gets an unmanaged equivalent of this scheduler.
+     *
+     * @return unmanaged equivalent of this scheduler
+     */
+    @NotNull BukkitScheduler asUnmanaged();
+
+    // `scheduleSync*`
+
+    /**
+     * <p>Schedules a once off task to occur after a delay.</p>
+     * <p>This task will be executed by the main server thread.</p>
+     *
+     * @param task task to be executed
+     * @param delay delay in server ticks before executing the task
+     * @return task ID or {@code -1} if scheduling failed
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#scheduleSyncDelayedTask(org.bukkit.plugin.Plugin, Runnable, long) unmanaged equivalent
+     */
+    int scheduleSyncDelayedTask(@NonNull Runnable task, long delay);
+
+    /**
+     * <p>Schedules a once off task to occur as soon as possible.</p>
+     * <p>This task will be executed by the main server thread.</p>
+     *
+     * @param task task to be executed
+     * @return task ID or {@code -1} if scheduling failed
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#scheduleSyncDelayedTask(org.bukkit.plugin.Plugin, Runnable) unmanaged equivalent
+     */
+    int scheduleSyncDelayedTask(@NonNull Runnable task);
+
+    /**
+     * <p>Schedules a repeating task.</p>
+     * <p>This task will be executed by the main server thread.</p>
+     *
+     * @param task task to be executed
+     * @param delay delay in server ticks before executing the task
+     * @return task ID or {@code -1} if scheduling failed
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#scheduleSyncRepeatingTask(org.bukkit.plugin.Plugin, Runnable, long, long)
+     * unmanaged equivalent
+     */
+    int scheduleSyncRepeatingTask(@NonNull Runnable task, long delay, long period);
+
+    // general purpose methods
+
+    /**
+     * <p>Calls a method on the main thread and returns a {@link Future} object.</p>
+     * <p>This task will be executed by the main server thread.</p>
+     *
+     * @param task task to be executed
+     * @param <T> result of the callable's execution
+     * @return future which will contain the result once the task is executed
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#callSyncMethod(org.bukkit.plugin.Plugin, Callable) unmanaged equivalent
+     */
+    <T> @NotNull Future<T> callSyncMethod(@NonNull Callable<T> task);
+
+    // `runTask[Asynchronously]`
+
+    /**
+     * Creates a task to be run on the next server tick.
+     *
+     * @param task task to be executed
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Runnable) unmanaged equivalent
+     */
+    @NotNull BukkitTask runTask(@NonNull Runnable task);
+
+    /**
+     * Creates a task to be run on the next server tick.
+     *
+     * @param task task to be executed
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Consumer) unmanaged equivalent
+     */
+    void runTask(@NonNull Consumer<@NotNull BukkitTask> task);
+
+    /**
+     * Creates a task to be run asynchronously.
+     *
+     * @param task task to be executed
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskAsynchronously(org.bukkit.plugin.Plugin, Runnable) unmanaged equivalent
+     */
+    @NotNull BukkitTask runTaskAsynchronously(@NonNull Runnable task);
+
+    /**
+     * Creates a task to be run asynchronously.
+     *
+     * @param task task to be executed
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskLaterAsynchronously(org.bukkit.plugin.Plugin, Consumer, long) unmanaged equivalent
+     */
+    void runTaskAsynchronously(@NonNull Consumer<@NotNull BukkitTask> task);
+
+    // `runTaskLater[Asynchronously]`
+
+    /**
+     * Creates a task to be run after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskLater(org.bukkit.plugin.Plugin, Runnable, long) unmanaged equivalent
+     */
+    @NotNull BukkitTask runTaskLater(@NonNull Runnable task, long delay);
+
+    /**
+     * Creates a task to be run after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskLater(org.bukkit.plugin.Plugin, Consumer, long) unmanaged equivalent
+     */
+    void runTaskLater(@NonNull Consumer<@NotNull BukkitTask> task, long delay);
+
+    /**
+     * Creates a task to be run asynchronously after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskLaterAsynchronously(org.bukkit.plugin.Plugin, Runnable, long) unmanaged equivalent
+     */
+    @NotNull BukkitTask runTaskLaterAsynchronously(@NonNull Runnable task, long delay);
+
+    /**
+     * Creates a task to be run asynchronously after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskLaterAsynchronously(org.bukkit.plugin.Plugin, Consumer, long) unmanaged equivalent
+     */
+    void runTaskLaterAsynchronously(@NonNull Consumer<@NotNull BukkitTask> task, long delay);
+
+    // `runTaskTimer[Asynchronously]`
+
+    /**
+     * Creates a task to be repeatedly run until cancelled,
+     * starting after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @param period number of ticks to wait between runs
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskTimer(org.bukkit.plugin.Plugin, Runnable, long, long) unmanaged equivalent
+     */
+    @NotNull BukkitTask runTaskTimer(@NonNull Runnable task, long delay, long period);
+
+    /**
+     * Creates a task to be repeatedly run until cancelled,
+     * starting after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @param period number of ticks to wait between runs
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskTimer(org.bukkit.plugin.Plugin, Consumer, long, long) unmanaged equivalent
+     */
+    void runTaskTimer(@NonNull Consumer<@NotNull BukkitTask> task, long delay, long period);
+
+    /**
+     * Creates a task to be repeatedly run asynchronously until cancelled,
+     * starting after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @param period number of ticks to wait between runs
+     * @return created task
+     *
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskTimerAsynchronously(org.bukkit.plugin.Plugin, Runnable, long, long)
+     * unmanaged equivalent
+     */
+    @NotNull BukkitTask runTaskTimerAsynchronously(@NonNull Runnable task, long delay, long period);
+
+    /**
+     * Creates a task to be repeatedly run asynchronously until cancelled,
+     * starting after the specified number of server ticks.
+     *
+     * @param task task to be executed
+     * @param delay number of ticks to wait before running the task
+     * @param period number of ticks to wait between runs
+     * @throws NullPointerException if {@code task} is {@code null}
+     * @see BukkitScheduler#runTaskTimerAsynchronously(org.bukkit.plugin.Plugin, Consumer, long, long)
+     * unmanaged equivalent
+     */
+    void runTaskTimerAsynchronously(@NonNull Consumer<BukkitTask> task, long delay, long period);
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/PluginManagedBukkitScheduler.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/PluginManagedBukkitScheduler.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.scheduler;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+/**
+ * {@link Plugin}-managed {@link BukkitScheduler} wrapped into a {@link ManagedBukkitScheduler}.
+ */
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public final class PluginManagedBukkitScheduler implements ManagedBukkitScheduler {
+
+    /**
+     * Internal Bukkit scheduler
+     */
+    @NotNull BukkitScheduler scheduler;
+
+    /**
+     * Owner of this scheduler wrapper
+     */
+    @NotNull Plugin owner;
+
+    /**
+     * Creates a new {@link Plugin}-managed {@link BukkitScheduler} wrapped into a {@link ManagedBukkitScheduler}.
+     *
+     * @param plugin plugin owning the created scheduler wrapper
+     * @return created wrapper around Bukkit scheduler owned by the plugin
+     */
+    public static @NotNull ManagedBukkitScheduler create(final @NotNull Plugin plugin) {
+        return new PluginManagedBukkitScheduler(plugin.getServer().getScheduler(), plugin);
+    }
+
+    @Override
+    public @NotNull BukkitScheduler asUnmanaged() {
+        return scheduler;
+    }
+
+    @Override
+    public int scheduleSyncDelayedTask(@NonNull final Runnable task, final long delay) {
+        return scheduler.scheduleSyncDelayedTask(owner, task, delay);
+    }
+
+    @Override
+    public int scheduleSyncDelayedTask(@NonNull final Runnable task) {
+        return scheduler.scheduleSyncDelayedTask(owner, task);
+    }
+
+    @Override
+    public int scheduleSyncRepeatingTask(@NonNull final Runnable task, final long delay, final long period) {
+        return scheduler.scheduleSyncRepeatingTask(owner, task, delay, period);
+    }
+
+    @Override
+    public @NotNull <T> Future<T> callSyncMethod(@NonNull final Callable<T> task) {
+        return scheduler.callSyncMethod(owner, task);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTask(@NonNull final Runnable task) {
+        return scheduler.runTask(owner, task);
+    }
+
+    @Override
+    public void runTask(@NonNull final Consumer<@NotNull BukkitTask> task) {
+        scheduler.runTask(owner, task);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTaskAsynchronously(@NonNull final Runnable task) {
+        return scheduler.runTaskAsynchronously(owner, task);
+    }
+
+    @Override
+    public void runTaskAsynchronously(@NonNull final Consumer<@NotNull BukkitTask> task) {
+        scheduler.runTaskAsynchronously(owner, task);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTaskLater(@NonNull final Runnable task, final long delay) {
+        return scheduler.runTaskLater(owner, task, delay);
+    }
+
+    @Override
+    public void runTaskLater(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay) {
+        scheduler.runTaskLater(owner, task, delay);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTaskLaterAsynchronously(@NonNull final Runnable task, final long delay) {
+        return scheduler.runTaskLaterAsynchronously(owner, task, delay);
+    }
+
+    @Override
+    public void runTaskLaterAsynchronously(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay) {
+        scheduler.runTaskLaterAsynchronously(owner, task, delay);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTaskTimer(@NonNull final Runnable task, final long delay, final long period) {
+        return scheduler.runTaskTimer(owner, task, delay, period);
+    }
+
+    @Override
+    public void runTaskTimer(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay, final long period) {
+        scheduler.runTaskTimer(owner, task, delay, period);
+    }
+
+    @Override
+    public @NotNull BukkitTask runTaskTimerAsynchronously(@NonNull final Runnable task, final long delay,
+                                                          final long period) {
+        return scheduler.runTaskTimerAsynchronously(owner, task, delay, period);
+    }
+
+    @Override
+    public void runTaskTimerAsynchronously(@NonNull final Consumer<BukkitTask> task, final long delay,
+                                           final long period) {
+        scheduler.runTaskTimerAsynchronously(owner, task, delay, period);
+    }
+}

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/PluginManagedBukkitScheduler.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/scheduler/PluginManagedBukkitScheduler.java
@@ -62,83 +62,83 @@ public final class PluginManagedBukkitScheduler implements ManagedBukkitSchedule
     }
 
     @Override
-    public int scheduleSyncDelayedTask(@NonNull final Runnable task, final long delay) {
+    public int scheduleSyncDelayedTask(final @NonNull Runnable task, final long delay) {
         return scheduler.scheduleSyncDelayedTask(owner, task, delay);
     }
 
     @Override
-    public int scheduleSyncDelayedTask(@NonNull final Runnable task) {
+    public int scheduleSyncDelayedTask(final @NonNull Runnable task) {
         return scheduler.scheduleSyncDelayedTask(owner, task);
     }
 
     @Override
-    public int scheduleSyncRepeatingTask(@NonNull final Runnable task, final long delay, final long period) {
+    public int scheduleSyncRepeatingTask(final @NonNull Runnable task, final long delay, final long period) {
         return scheduler.scheduleSyncRepeatingTask(owner, task, delay, period);
     }
 
     @Override
-    public @NotNull <T> Future<T> callSyncMethod(@NonNull final Callable<T> task) {
+    public @NotNull <T> Future<T> callSyncMethod(final @NonNull Callable<T> task) {
         return scheduler.callSyncMethod(owner, task);
     }
 
     @Override
-    public @NotNull BukkitTask runTask(@NonNull final Runnable task) {
+    public @NotNull BukkitTask runTask(final @NonNull Runnable task) {
         return scheduler.runTask(owner, task);
     }
 
     @Override
-    public void runTask(@NonNull final Consumer<@NotNull BukkitTask> task) {
+    public void runTask(final @NonNull Consumer<@NotNull BukkitTask> task) {
         scheduler.runTask(owner, task);
     }
 
     @Override
-    public @NotNull BukkitTask runTaskAsynchronously(@NonNull final Runnable task) {
+    public @NotNull BukkitTask runTaskAsynchronously(final @NonNull Runnable task) {
         return scheduler.runTaskAsynchronously(owner, task);
     }
 
     @Override
-    public void runTaskAsynchronously(@NonNull final Consumer<@NotNull BukkitTask> task) {
+    public void runTaskAsynchronously(final @NonNull Consumer<@NotNull BukkitTask> task) {
         scheduler.runTaskAsynchronously(owner, task);
     }
 
     @Override
-    public @NotNull BukkitTask runTaskLater(@NonNull final Runnable task, final long delay) {
+    public @NotNull BukkitTask runTaskLater(final @NonNull Runnable task, final long delay) {
         return scheduler.runTaskLater(owner, task, delay);
     }
 
     @Override
-    public void runTaskLater(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay) {
+    public void runTaskLater(final @NonNull Consumer<@NotNull BukkitTask> task, final long delay) {
         scheduler.runTaskLater(owner, task, delay);
     }
 
     @Override
-    public @NotNull BukkitTask runTaskLaterAsynchronously(@NonNull final Runnable task, final long delay) {
+    public @NotNull BukkitTask runTaskLaterAsynchronously(final @NonNull Runnable task, final long delay) {
         return scheduler.runTaskLaterAsynchronously(owner, task, delay);
     }
 
     @Override
-    public void runTaskLaterAsynchronously(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay) {
+    public void runTaskLaterAsynchronously(final @NonNull Consumer<@NotNull BukkitTask> task, final long delay) {
         scheduler.runTaskLaterAsynchronously(owner, task, delay);
     }
 
     @Override
-    public @NotNull BukkitTask runTaskTimer(@NonNull final Runnable task, final long delay, final long period) {
+    public @NotNull BukkitTask runTaskTimer(final @NonNull Runnable task, final long delay, final long period) {
         return scheduler.runTaskTimer(owner, task, delay, period);
     }
 
     @Override
-    public void runTaskTimer(@NonNull final Consumer<@NotNull BukkitTask> task, final long delay, final long period) {
+    public void runTaskTimer(final @NonNull Consumer<@NotNull BukkitTask> task, final long delay, final long period) {
         scheduler.runTaskTimer(owner, task, delay, period);
     }
 
     @Override
-    public @NotNull BukkitTask runTaskTimerAsynchronously(@NonNull final Runnable task, final long delay,
+    public @NotNull BukkitTask runTaskTimerAsynchronously(final @NonNull Runnable task, final long delay,
                                                           final long period) {
         return scheduler.runTaskTimerAsynchronously(owner, task, delay, period);
     }
 
     @Override
-    public void runTaskTimerAsynchronously(@NonNull final Consumer<BukkitTask> task, final long delay,
+    public void runTaskTimerAsynchronously(final @NonNull Consumer<BukkitTask> task, final long delay,
                                            final long period) {
         scheduler.runTaskTimerAsynchronously(owner, task, delay, period);
     }


### PR DESCRIPTION
# Description

This adds `ManagedBukkitScheduler` wrapper around `BukkitScheduler` to allow its usage without explicit passing of `Plugin` instances.