### PR TITLE
Allow manual GitHub Workflow  dispatch

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -3,6 +3,7 @@ name: Deploy snapshot
 on:
   push:
     branches: [ development ]
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 # Only test (without creating JARs) pull-requests
-on: [ pull_request ]
+on: [ pull_request, workflow_dispatch ]
 
 jobs:
   test:


### PR DESCRIPTION
# Description

This enables `workflow_dispatch` for all workflows except for `Deploy release`.