### PR TITLE
feat: use reactive CAS for Dynamic and specify its external-ness

### DIFF
--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/CompareAndSetOperation.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/CompareAndSetOperation.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
  * Atomic compare-and-set operation.
  *
  * @param <T> type of manipulated values
+ * @see ReactiveCompareAndSetOperation reactive equivalent
  */
 @FunctionalInterface
 public interface CompareAndSetOperation<T> {

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
@@ -173,10 +173,10 @@ public interface Dynamic<T> {
                     null, null, true, false
             );
 
-            public ShouldRetry(final @Nullable String message,
-                               final @Nullable Throwable cause,
-                               final boolean enableSuppression,
-                               final boolean writableStackTrace) {
+            private ShouldRetry(final @Nullable String message,
+                                final @Nullable Throwable cause,
+                                final boolean enableSuppression,
+                                final boolean writableStackTrace) {
                 super(message, cause, enableSuppression, writableStackTrace);
             }
         }

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
@@ -97,9 +97,11 @@ public interface Dynamic<T> {
             + "_, null, _ -> fail;"
             + "_, _, null -> fail;"
             + "_, _, _ -> new;")
-    static <T> @NotNull Dynamic<T> create(final @NonNull CompareAndSetOperation<@NotNull ? super T> externalWriter,
-                                          final @NonNull Publisher<? extends T> publisher,
-                                          final @NonNull T initialValue) {
+    static <T> @NotNull Dynamic<T> create(
+            final @NonNull ReactiveCompareAndSetOperation<@NotNull ? super T> externalWriter,
+            final @NonNull Publisher<? extends T> publisher,
+            final @NonNull T initialValue
+    ) {
         val sink = Sinks.many().replay().latestOrDefault(initialValue);
         // TODO: handle emit errors
         Flux.from(publisher)
@@ -131,7 +133,7 @@ public interface Dynamic<T> {
         /**
          * Operation responsible for performing atomic compare-and-swap.
          */
-        @NotNull CompareAndSetOperation<@NotNull ? super T> externalWriter;
+        @NotNull ReactiveCompareAndSetOperation<@NotNull ? super T> externalWriter;
 
         @Override
         public @Nullable T snapshot() {
@@ -147,7 +149,7 @@ public interface Dynamic<T> {
         @Override
         public @NotNull Mono<Boolean> trySet(final @NotNull T newValue) {
             return asFlux.next()
-                    .map(current -> externalWriter.compareAndSet(current, newValue));
+                    .flatMap(current -> externalWriter.compareAndSet(current, newValue));
         }
 
         @Override

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/Dynamic.java
@@ -81,7 +81,7 @@ public interface Dynamic<T> {
     @NotNull Flux<? extends T> asFlux();
 
     /**
-     * Creates a new dynamic value.
+     * Creates a new externally changed dynamic value.
      *
      * @param externalWriter function used to perform atomic compare-and-set of the value globally
      * @param publisher publisher emitting values on external value changes
@@ -97,13 +97,12 @@ public interface Dynamic<T> {
             + "_, null, _ -> fail;"
             + "_, _, null -> fail;"
             + "_, _, _ -> new;")
-    static <T> @NotNull Dynamic<T> create(
+    static <T> @NotNull Dynamic<T> createExternal(
             final @NonNull ReactiveCompareAndSetOperation<@NotNull ? super T> externalWriter,
             final @NonNull Publisher<? extends T> publisher,
             final @NonNull T initialValue
     ) {
         val sink = Sinks.many().replay().latestOrDefault(initialValue);
-        // TODO: handle emit errors
         Flux.from(publisher)
                 .subscribe(
                         value -> sink.emitNext(value, Sinks.EmitFailureHandler.FAIL_FAST),
@@ -111,18 +110,19 @@ public interface Dynamic<T> {
                         () -> sink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST)
                 );
 
-        return new ReactorDynamic<>(sink.asFlux(), externalWriter);
+        return new ExternalDynamic<>(sink.asFlux(), externalWriter);
     }
 
     /**
-     * {@link Dynamic} implementation which stores the {@link Flux} representation of {@link Sinks.Many}.
+     * {@link Dynamic} implementation which stores the {@link Flux} representation of {@link Sinks.Many}
+     * and relies on external changes.
      *
      * @param <T> type of dynamic value
      */
     //@formatter:off (don't merge last annotation and class declaration lines)
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-    final class ReactorDynamic<T> implements Dynamic<T> {
+    final class ExternalDynamic<T> implements Dynamic<T> {
         //@formatter:on
 
         /**

--- a/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/ReactiveCompareAndSetOperation.java
+++ b/zaraza-common-api/src/main/java/ru/divinecraft/zaraza/common/api/reactor/ReactiveCompareAndSetOperation.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.divinecraft.zaraza.common.api.reactor;
+
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive atomic compare-and-set operation.
+ *
+ * @param <T> type of manipulated values
+ * @see CompareAndSetOperation non-reactive equivalent
+ */
+@FunctionalInterface
+public interface ReactiveCompareAndSetOperation<T> {
+
+    /**
+     * Asynchronously performs compare-and-set operation
+     *
+     * @param oldValue the expected value
+     * @param newValue the new value
+     * @return mono emitting {@code true} if the operation succeeds or {@code false} otherwise
+     */
+    @NotNull Mono<Boolean> compareAndSet(T oldValue, T newValue);
+
+    /**
+     * Creates a reactive compare-ans-set operation which never succeeds.
+     *
+     * @param <T> type of manipulated values
+     * @return created impossible reactive compare-and-set operation
+     */
+    static @NotNull <T> ReactiveCompareAndSetOperation<T> impossible() {
+        return (oldValue, newValue) -> Mono.just(false);
+    }
+}

--- a/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/reactor/DynamicTest.java
+++ b/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/reactor/DynamicTest.java
@@ -31,7 +31,7 @@ class DynamicTest {
         val sink = Sinks.many()
                 .unicast()
                 .<String>onBackpressureError();
-        val dynamic = Dynamic.create((oldValue, newValue) -> {
+        val dynamic = Dynamic.createExternal((oldValue, newValue) -> {
             sink.emitNext(newValue, Sinks.EmitFailureHandler.FAIL_FAST);
             return true;
         }, sink.asFlux(), "initial");
@@ -53,7 +53,7 @@ class DynamicTest {
         val sink = Sinks.many()
                 .unicast()
                 .<String>onBackpressureError();
-        val dynamic = Dynamic.create((oldValue, newValue) -> {
+        val dynamic = Dynamic.createExternal((oldValue, newValue) -> {
             // succeed CAS only after multiple attempts
             if (attemptsBeforeSuccess.decrementAndGet() == 0) {
                 sink.emitNext(newValue, Sinks.EmitFailureHandler.FAIL_FAST);

--- a/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/reactor/DynamicTest.java
+++ b/zaraza-common-api/src/test/java/ru/divinecraft/zaraza/common/api/reactor/DynamicTest.java
@@ -17,6 +17,7 @@ package ru.divinecraft.zaraza.common.api.reactor;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
@@ -27,13 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DynamicTest {
 
     @Test
-    void dynamic_create__multicasts() {
+    void dynamic_createExternal__multicasts() {
         val sink = Sinks.many()
                 .unicast()
                 .<String>onBackpressureError();
         val dynamic = Dynamic.createExternal((oldValue, newValue) -> {
             sink.emitNext(newValue, Sinks.EmitFailureHandler.FAIL_FAST);
-            return true;
+            return Mono.just(true);
         }, sink.asFlux(), "initial");
 
         assertDynamicReplays(dynamic, "initial", 1, 3, 54, 4, 64, 3, 2);
@@ -47,7 +48,7 @@ class DynamicTest {
     }
 
     @Test
-    void dynamic_create__update() {
+    void dynamic_createExternal__update() {
         val attemptsBeforeSuccess = new AtomicInteger(77);
 
         val sink = Sinks.many()
@@ -58,10 +59,10 @@ class DynamicTest {
             if (attemptsBeforeSuccess.decrementAndGet() == 0) {
                 sink.emitNext(newValue, Sinks.EmitFailureHandler.FAIL_FAST);
 
-                return true;
+                return Mono.just(true);
             }
 
-            return false;
+            return Mono.just(false);
         }, sink.asFlux(), "foo");
 
         assertDynamicReplays(dynamic, "foo", 121, 21, 486, 4, 525, 653, 364, 4);


### PR DESCRIPTION
# Description

Use new interface `ReactiveCompareAndSetOperation` and use it instead of `CompareAndSetOperation`.

This also renames members of `Dynamic` to explicitly specify external source.