### PR TITLE
ci: shorten Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     target-branch: development
-    reviewers:
-      - divine-craft/senior-developer
+    reviewers: [ divine-craft/senior-developer ]
     labels:
       - dependencies
       - automatic
@@ -18,8 +17,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     target-branch: development
-    reviewers:
-      - divine-craft/senior-developer
+    reviewers: [ divine-craft/senior-developer ]
     labels:
       - dependencies
       - automatic


### PR DESCRIPTION
# Description

This replaces multi-line array syntax siwth single-lne one in `dependabot.yml`.