### PR TITLE
build(dep): update `padla` to `1.0.0-rc.5`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <version.zaraza>1.0.0-SNAPSHOT</version.zaraza>
         <zaraza.rootPackage>ru.divinecraft.zaraza</zaraza.rootPackage>
         <zaraza.libPackage>${zaraza.rootPackage}.lib</zaraza.libPackage>
-        <version.padla>1.0.0-rc.4</version.padla>
+        <version.padla>1.0.0-rc.5</version.padla>
         <version.minecraft-utils>1.0.0-SNAPSHOT</version.minecraft-utils>
         <version.jooq>3.15.1</version.jooq>
         <version.r2dbc-migrate>1.7.0</version.r2dbc-migrate>


### PR DESCRIPTION
# Description

This updates `padla` to version `1.0.0-rc.5` which (among other changes) publishes the `DataSerializer` API originally being a proprietary part of `mc-sharder`.