### PR TITLE
fix: retry external Dynamic only when explicitly required

### DIFF
--- a/zaraza-common-api/pom.xml
+++ b/zaraza-common-api/pom.xml
@@ -154,6 +154,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
# Description

Now `Dynamic`s created via `Dynamic#createExternal(..)` will only perform retry internally when it is explicitly requested.